### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM ruby:2.7.1
+WORKDIR /app
+COPY Gemfile Gemfile.lock .
+RUN bundle config set force_ruby_platform true && bundle install
+COPY . .
+ENTRYPOINT ["ruby", "notes_cloud_ripper.rb"]


### PR DESCRIPTION
This makes it easier to run the app cross-platform, without worrying about local ruby versions etc:

```bash
git clone git@github.com:threeplanetssoftware/apple_cloud_notes_parser.git
cd apple_cloud_notes_parser
docker build -t apple_cloud_notes_parser .
docker run --rm \
  -v ~/Library/Group\ Containers/group.com.apple.notes:/data:ro \
  -v $(pwd)/my_notes_backup:/app/output \
  apple_cloud_notes_parser \
  --mac /data --one-output-folder
ls my_notes_backup/
```

Also, if you'd like, you can [push the image to GitHub](https://docs.github.com/en/actions/publishing-packages/publishing-docker-images):

```bash
docker build -t ghcr.io/threeplanetssoftware/apple_cloud_notes_parser:latest .
docker push ghcr.io/threeplanetssoftware/apple_cloud_notes_parser:latest
```

So then folks don't need to even clone/build, just have Docker installed:

```bash
docker run --rm \
  -v ~/Library/Group\ Containers/group.com.apple.notes:/data:ro \
  -v $(pwd)/my_notes_backup:/app/output \
  ghcr.io/threeplanetssoftware/apple_cloud_notes_parser \
  --mac /data --one-output-folder
```

Thanks again for the fantastic app!