### PR TITLE
Add support for notes with ".log" file attachments

### DIFF
--- a/lib/AppleUniformTypeIdentifier.rb
+++ b/lib/AppleUniformTypeIdentifier.rb
@@ -88,6 +88,7 @@ class AppleUniformTypeIdentifier
   # This method returns true if the UTI conforms to public.data objets that are likely documents
   def conforms_to_document
     return false if bad_uti?
+    return true if @uti == "com.apple.log"
     return true if @uti == "com.microsoft.word.doc"
     return true if @uti == "com.microsoft.excel.xls"
     return true if @uti == "com.microsoft.powerpoint.ppt"


### PR DESCRIPTION
I had a note with a `.log` file attachment inside of it, which generated this error previously (and omitted the `.log` file from the export):

```
com.apple.log is unrecognized ZTYPEUTI
```

I'm not positive this is the correct solution, but treating this log type like other documents in the code seems to result in what I'd expect: The log file is output as a plain text file, and the note contains a link to it.