### PR TITLE
Add structured export html

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ The options that are currently supported are:
 8. `--show-password-successes`: Tells the program to display to the console which passwords generated decrypts at the end.
 9. `--range-start DATE`: Set the start date of the date range to extract. Must use YYYY-MM-DD format, defaults to 1970-01-01.
 10. `--range-end DATE`: Set the end date of the date range to extract. Must use YYYY-MM-DD format, defaults to [tomorrow].
-11. `-h | --help`: Prints the usage information.
+11. `--individual-files`: Output individual HTML files for each note, organized in folders mirroring the Notes folder structure.
+12. `--uuid`: Use UUIDs in HTML output rather than local database IDs.
+13. `-h | --help`: Prints the usage information.
 
 ## How It Works
 
@@ -163,6 +165,10 @@ This means that pinned notes will appear before unpinned notes and notes within 
 The order of note content at the bottom of the page will retain database order, by the note's ID (i.e. if Note 14 will come after Note 13 and before Note 15, regardless of which folders they are in). 
 Soon the folder names themselves will also reflect the ordering as it appears in Apple Notes. 
 
+If the `--individual-files` option is passed, then the HTML output will be produced as individual files for each note, organized in folders that mirror the Notes folder hierarchy. This can be useful for comparing successive exports to see which notes have changed.
+
+If the `--uuid` option is passed, then the HTML output will refer to notes by their UUID (taken from `ZICCLOUDSYNCINGOBJECT.ZIDENTIFIER`) rather than the integer ID used in the local database. These UUIDs should be consistent across devices synced with iCloud, whereas the integer IDs will be specific to each device.
+
 This program will produce four CSV files summarizing the information stored in `[location of this program]/output/[date of run]/csv`: `note_store_accounts.csv`, `note_store_embedded_objects.csv`, `note_store_folders.csv`, and `note_store_notes.sqlite`. 
 It will also produce an HTML dump of the notes to reflect the text and table formatting which may be meaningful in `[location of this program]/output/[date of run]/html`. 
 Finally, it will produce a JSON dump for each of the NoteStore files, summarizing the accounts, folders, and notes within that NoteStore file.
@@ -229,6 +235,7 @@ The JSON output of `AppleNotesFolder` is as follows.
 ``` json
 {
   "primary_key": "[integer folder z_pk]",
+  "uuid": "[folder uuid from ZICCLOUDSYNCINGOBJECT.ZIDENTIFIER]",
   "name": "[folder name]",
   "account_id": "[integer z_pk for the account this belongs to]",
   "account": "[account name]",

--- a/lib/AppleNote.rb
+++ b/lib/AppleNote.rb
@@ -378,14 +378,23 @@ class AppleNote < AppleCloudKitRecord
     return to_return
   end
 
-  def title_as_filename(ext = '')
-    "#{@note_id} - #{@title.tr('/:', '_')}#{ext}"
-  end
-
   ## 
   # This method returns all the embedded objects in an AppleNote as an Array.
   def all_embedded_objects
     @embedded_objects + @embedded_objects_recursive
+  end
+
+  ##
+  # Unique ID for the note — prefer UUID if available, fall back to database ID
+  def unique_id
+    return @unique_id if defined?(@unique_id)
+    @unique_id = uuid.empty? ? note_id : uuid
+  end
+
+  ##
+  # Generate a file name for exporting this note to an HTML file
+  def title_as_filename(ext = '')
+    "#{unique_id} - #{title.tr('/:', '_')}#{ext}"
   end
 
   ##
@@ -398,8 +407,8 @@ class AppleNote < AppleCloudKitRecord
     builder = Nokogiri::HTML::Builder.new(encoding: "utf-8") do |doc|
       doc.div {
         doc.h1 {
-          doc.a(id: "note_#{@note_id}") {
-            doc.text "Note #{@note_id}#{" (📌)" if @is_pinned}"
+          doc.a(id: "note_#{unique_id}") {
+            doc.text "Note #{unique_id}#{" (📌)" if @is_pinned}"
           }
         }
 

--- a/lib/AppleNote.rb
+++ b/lib/AppleNote.rb
@@ -68,6 +68,7 @@ class AppleNote < AppleCloudKitRecord
                 :database,
                 :decompressed_data,
                 :account,
+                :folder,
                 :backup,
                 :crypto_password,
                 :cloudkit_creator_record_id,
@@ -377,6 +378,10 @@ class AppleNote < AppleCloudKitRecord
     return to_return
   end
 
+  def title_as_filename(ext = '')
+    "#{@note_id} - #{@title.tr('/:', '_')}#{ext}"
+  end
+
   ## 
   # This method returns all the embedded objects in an AppleNote as an Array.
   def all_embedded_objects
@@ -387,10 +392,8 @@ class AppleNote < AppleCloudKitRecord
   # This method generates HTML to represent this Note, its 
   # metadata, and its contents, if applicable. It does not generate 
   # full HTML, just enough for this note's card to be displayed.
-  def generate_html
-
-    # Bail quickly if we've ever taken the time to build this before
-    return @html if @html
+  def generate_html(individual_files = false)
+    folder_href = individual_files ? "index.html" : "#folder_#{@folder.primary_key}"
 
     builder = Nokogiri::HTML::Builder.new(encoding: "utf-8") do |doc|
       doc.div {
@@ -415,7 +418,7 @@ class AppleNote < AppleCloudKitRecord
           }
 
           doc.text " "
-          doc.a(href: "#folder_#{@folder.primary_key}") {
+          doc.a(href: folder_href) {
             doc.text @folder.name
           }
         }
@@ -508,7 +511,7 @@ class AppleNote < AppleCloudKitRecord
       }
     end
 
-    @html = builder.doc.root
+    builder.doc.root
   end
 
   ##

--- a/lib/AppleNoteStore.rb
+++ b/lib/AppleNoteStore.rb
@@ -845,8 +845,83 @@ class AppleNoteStore
     end
   end
 
-  def generate_html
+  HTML_STYLES = <<~EOS
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+      font-size: 13px;
+    }
+    h1, h2, h3 {
+      margin: 0px;
+    }
+    .note-cards {
+      display: grid;
+      grid-template-columns: repeat(1, 1fr);
+      grid-auto-rows: auto;
+      grid-gap: 1rem;
+    }
+    .note-card {
+      border: 2px solid black;
+      border-radius: 3px;
+      padding: .5rem;
+    }
+    .note-content {
+      margin-top: 1rem;
+    }
+    pre {
+      margin: 0px;
+    }
+    ul, ol, blockquote {
+      padding: 0px 0px 0px 2rem;
+      margin: 0px;
+    }
+    ul.none, ol.none {
+      list-style-type: none;
+    }
+    ul.dashed {
+      list-style-type: '- ';
+    }
+    .checklist {
+      position: relative;
+      list-style: none;
+      margin-left: 0;
+      padding-left: 1.2em;
+    }
+    .checklist li.checked:before {
+      content: '☑';
+      position: absolute;
+      left: 0;
+    }
+    .checklist li.unchecked:before {
+      content: '☐';
+      position: absolute;
+      left: 0;
+    }
+    .folder_list {
+      position: relative;
+      list-style: none;
+      margin-left: 0;
+      padding-left: 1.2em;
+    }
+    .folder_list li.folder:before {
+      content: '📁';
+      position: absolute;
+      left: 0;
+    }
+    .folder_list li.note:before {
+      content: '📄';
+      position: absolute;
+      left: 0;
+    }
+    table {
+      border-collapse: collapse;
+    }
+    table td {
+      border: 1px solid black;
+      padding: 0.3em;
+    }
+  EOS
 
+  def generate_html
     # Bail early if we can
     return @html if @html
 
@@ -855,81 +930,7 @@ class AppleNoteStore
       doc.html {
         doc.head {
           doc.meta(charset: "utf-8")
-          doc.style <<~EOS
-            body {
-              font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-              font-size: 13px;
-            }
-            h1, h2, h3 {
-              margin: 0px;
-            }
-            .note-cards {
-              display: grid;
-              grid-template-columns: repeat(1, 1fr);
-              grid-auto-rows: auto;
-              grid-gap: 1rem;
-            }
-            .note-card {
-              border: 2px solid black;
-              border-radius: 3px;
-              padding: .5rem;
-            }
-            .note-content {
-              margin-top: 1rem;
-            }
-            pre {
-              margin: 0px;
-            }
-            ul, ol, blockquote {
-              padding: 0px 0px 0px 2rem;
-              margin: 0px;
-            }
-            ul.none, ol.none {
-              list-style-type: none;
-            }
-            ul.dashed {
-              list-style-type: '- ';
-            }
-            .checklist {
-              position: relative;
-              list-style: none;
-              margin-left: 0;
-              padding-left: 1.2em;
-            }
-            .checklist li.checked:before {
-              content: '☑';
-              position: absolute;
-              left: 0;
-            }
-            .checklist li.unchecked:before {
-              content: '☐';
-              position: absolute;
-              left: 0;
-            }
-            .folder_list {
-              position: relative;
-              list-style: none;
-              margin-left: 0;
-              padding-left: 1.2em;
-            }
-            .folder_list li.folder:before {
-              content: '📁';
-              position: absolute;
-              left: 0;
-            }
-            .folder_list li.note:before {
-              content: '📄';
-              position: absolute;
-              left: 0;
-            }
-            table {
-              border-collapse: collapse;
-            }
-            table td {
-              border: 1px solid black;
-              padding: 0.3em;
-            }
-          EOS
+          doc.style(HTML_STYLES)
         }
 
         doc.body {
@@ -954,6 +955,57 @@ class AppleNoteStore
     end
 
     @html = builder.doc
+  end
+
+  def write_individual_html(backup_dir)
+    write_html_content(backup_dir.join("index.html"), "Notes") do |doc|
+      @accounts.each do |key, account|
+        doc << account.generate_html(true)
+      end
+    end
+
+    @folders.each do |folder_id, folder|
+      folder_path = backup_dir.join(folder.to_path)
+      folder_path.mkpath
+      write_html_content(folder_path.join("index.html"), folder.name) do |doc|
+        doc << folder.generate_html(true)
+      end
+    end
+
+    @notes.each do |note_id, note|
+      note_file_name = note.title_as_filename('.html')
+      note_path = if note.folder
+                    backup_dir.join(note.folder.to_path, note_file_name)
+                  else
+                    backup_dir.join(note_file_name)
+                  end
+      write_html_content(note_path, note.title) do |doc|
+        doc.div(class: "note-card") {
+          doc << note.generate_html(true)
+        }
+      end
+    end
+  end
+
+  def write_html_content(path, title)
+    document = Nokogiri::HTML5::Document.new
+    builder = Nokogiri::HTML::Builder.new({ encoding: "utf-8" }, document) do |doc|
+      doc.html {
+        doc.head {
+          doc.meta(charset: "utf-8")
+          doc.style(HTML_STYLES)
+          doc.title(title)
+        }
+
+        doc.body {
+          yield doc
+        }
+      }
+    end
+
+    File.open(path, "wb") do |file|
+      file.write(builder.doc)
+    end
   end
 
   ##

--- a/lib/AppleNoteStore.rb
+++ b/lib/AppleNoteStore.rb
@@ -592,6 +592,10 @@ class AppleNoteStore
                                                row["ZSMARTFOLDERQUERYJSON"])
       end
 
+      if row["ZIDENTIFIER"]
+        tmp_folder.uuid = row["ZIDENTIFIER"]
+      end
+
       # Set whether the folder displays notes in numeric order, or by modification date
       tmp_folder.retain_order = @retain_order
       tmp_folder.sort_order = @folder_order[row["ZIDENTIFIER"]] if @folder_order[row["ZIDENTIFIER"]]

--- a/lib/AppleNotesAccount.rb
+++ b/lib/AppleNotesAccount.rb
@@ -136,11 +136,7 @@ class AppleNotesAccount < AppleCloudKitRecord
 
   ##
   # This method generates HTML to display on the overall output.
-  def generate_html
-    
-    # Bail early if we can
-    return @html if @html
-
+  def generate_html(individual_files = false)
     builder = Nokogiri::HTML::Builder.new(encoding: "utf-8") do |doc|
       doc.div {
         doc.h1 {
@@ -196,14 +192,14 @@ class AppleNotesAccount < AppleCloudKitRecord
 
           doc.ul {
             sorted_folders.each do |folder|
-              doc << folder.generate_folder_hierarchy_html if !folder.is_child?
+              doc << folder.generate_folder_hierarchy_html(individual_files) if !folder.is_child?
             end
           }
         }
       }
     end
 
-    @html = builder.doc.root
+    builder.doc.root
   end
 
   ##

--- a/lib/AppleNotesAccount.rb
+++ b/lib/AppleNotesAccount.rb
@@ -136,7 +136,12 @@ class AppleNotesAccount < AppleCloudKitRecord
 
   ##
   # This method generates HTML to display on the overall output.
-  def generate_html(individual_files = false)
+  def generate_html(individual_files: false, use_uuid: false)
+    params = [individual_files, use_uuid]
+    if @html && @html[params]
+      return @html[params]
+    end
+
     builder = Nokogiri::HTML::Builder.new(encoding: "utf-8") do |doc|
       doc.div {
         doc.h1 {
@@ -192,14 +197,15 @@ class AppleNotesAccount < AppleCloudKitRecord
 
           doc.ul {
             sorted_folders.each do |folder|
-              doc << folder.generate_folder_hierarchy_html(individual_files) if !folder.is_child?
+              doc << folder.generate_folder_hierarchy_html(individual_files: individual_files, use_uuid: use_uuid) if !folder.is_child?
             end
           }
         }
       }
     end
 
-    builder.doc.root
+    @html ||= {}
+    @html[params] = builder.doc.root
   end
 
   ##

--- a/lib/AppleNotesFolder.rb
+++ b/lib/AppleNotesFolder.rb
@@ -184,10 +184,10 @@ class AppleNotesFolder < AppleCloudKitRecord
         doc.ul {
           # Now display whatever we ended up with
           sorted_notes.each do |note|
-            href = individual_files ? note.title_as_filename('.html') : "#note_#{note.note_id}"
+            href = individual_files ? note.title_as_filename('.html') : "#note_#{note.unique_id}"
             doc.li {
               doc.a(href: href) {
-                doc.text "Note #{note.note_id}"
+                doc.text "Note #{note.unique_id}"
               }
 
               doc.text ": #{note.title}#{" (📌)" if note.is_pinned}"

--- a/lib/AppleNotesSmartFolder.rb
+++ b/lib/AppleNotesSmartFolder.rb
@@ -34,7 +34,7 @@ class AppleNotesSmartFolder < AppleNotesFolder
     builder = Nokogiri::HTML::Builder.new(encoding: "utf-8") do |doc|
       doc.div {
         doc.h1 {
-          doc.a(id: "folder_#{@primary_key}") {
+          doc.a(id: "folder_#{unique_id}") {
             doc.text "#{@account.name} - #{full_name}"
           }
         }

--- a/lib/AppleNotesSmartFolder.rb
+++ b/lib/AppleNotesSmartFolder.rb
@@ -30,7 +30,7 @@ class AppleNotesSmartFolder < AppleNotesFolder
     return to_return
   end
 
-  def generate_html
+  def generate_html(_individual_files = false)
     builder = Nokogiri::HTML::Builder.new(encoding: "utf-8") do |doc|
       doc.div {
         doc.h1 {

--- a/lib/AppleNotesSmartFolder.rb
+++ b/lib/AppleNotesSmartFolder.rb
@@ -30,11 +30,11 @@ class AppleNotesSmartFolder < AppleNotesFolder
     return to_return
   end
 
-  def generate_html(_individual_files = false)
+  def generate_html(individual_files: false, use_uuid: false)
     builder = Nokogiri::HTML::Builder.new(encoding: "utf-8") do |doc|
       doc.div {
         doc.h1 {
-          doc.a(id: "folder_#{unique_id}") {
+          doc.a(id: "folder_#{unique_id(use_uuid)}") {
             doc.text "#{@account.name} - #{full_name}"
           }
         }

--- a/notes_cloud_ripper.rb
+++ b/notes_cloud_ripper.rb
@@ -22,6 +22,7 @@ retain_order = false
 target_directory = nil
 range_start = nil
 range_end = nil
+individual_files = false
 
 #
 # Options Parser setup
@@ -100,6 +101,11 @@ option_parser.on("--range-end DATE", "Set the end date of the date range to extr
     puts "Invalid date format #{date} given for --range-end. Please us the format YYYY-MM-DD."
     exit
   end
+end
+
+# Output individual HTML files for each note instead of one large file
+option_parser.on("--individual-files", "Output individual HTML files for each note, organized in folders mirroring the Notes folder structure.") do
+  individual_files = true
 end
 
 # Help information, only displayed if we haven't hit on other options
@@ -233,8 +239,14 @@ if apple_backup and apple_backup.valid? and apple_backup.note_stores.first.valid
 
     # Write out the HTML summary
     logger.debug("Writing HTML for Note Store")
-    File.open(html_directory + "all_notes_#{backup_number}.html", "wb") do |file|
-      file.write(note_store.generate_html)
+    if individual_files
+      note_store_subdirectory = html_directory + "note_store#{backup_number}"
+      note_store_subdirectory.mkpath
+      note_store.write_individual_html(note_store_subdirectory)
+    else
+      File.open(html_directory + "all_notes_#{backup_number}.html", "wb") do |file|
+        file.write(note_store.generate_html)
+      end
     end
 
     # Write out the JSON summary

--- a/notes_cloud_ripper.rb
+++ b/notes_cloud_ripper.rb
@@ -23,6 +23,7 @@ target_directory = nil
 range_start = nil
 range_end = nil
 individual_files = false
+use_uuid = false
 
 #
 # Options Parser setup
@@ -106,6 +107,11 @@ end
 # Output individual HTML files for each note instead of one large file
 option_parser.on("--individual-files", "Output individual HTML files for each note, organized in folders mirroring the Notes folder structure.") do
   individual_files = true
+end
+
+# Prefer UUIDs instead of local database IDs
+option_parser.on("--uuid", "Use UUIDs in HTML output rather than local database IDs.") do
+  use_uuid = true
 end
 
 # Help information, only displayed if we haven't hit on other options
@@ -242,10 +248,10 @@ if apple_backup and apple_backup.valid? and apple_backup.note_stores.first.valid
     if individual_files
       note_store_subdirectory = html_directory + "note_store#{backup_number}"
       note_store_subdirectory.mkpath
-      note_store.write_individual_html(note_store_subdirectory)
+      note_store.write_individual_html(note_store_subdirectory, use_uuid: use_uuid)
     else
       File.open(html_directory + "all_notes_#{backup_number}.html", "wb") do |file|
-        file.write(note_store.generate_html)
+        file.write(note_store.generate_html(use_uuid: use_uuid))
       end
     end
 


### PR DESCRIPTION
Hi, first off, thank you so much for writing this excellent tool! I spent a lot of time trying to figure out a good way to backup/export data from Apple Notes and this does a better job than anything else I found.

For my backups, I like to have notes exported as individual HTML files so that it's easier to keep track of history for each note. So this PR adds an option to export individual HTML files instead of one big one. The default is still to generate one HTML file. Let me know your thoughts on this.

I also included some changes to use UUID (aka ZIDENTIFIER in the Notes database) instead of the primary key id when possible. I found that the primary key would change depending on what device I ran the export on, whereas the UUID would remain stable. So for the purpose of consistent output, the UUID seems preferable. However, they are a bit long and unwieldy, so I could exclude those changes if you think they don't make sense for most use cases. I could also make a CLI flag for that if desired.

Anyway, thanks for taking a look and thanks again for the great work on this project.