### PR TITLE
Identify OGG as audio

### DIFF
--- a/lib/AppleUniformTypeIdentifier.rb
+++ b/lib/AppleUniformTypeIdentifier.rb
@@ -63,6 +63,7 @@ class AppleUniformTypeIdentifier
     return true if @uti == "public.aiff-audio"
     return true if @uti == "public.midi-audio"
     return true if @uti == "public.mp3"
+    return true if @uti == "org.xiph.ogg-audio"
     return false
   end
 


### PR DESCRIPTION
When testing my importer, I came across this UTI. Since Obsidian embeds all attachments in the same way, it isn't really relevant for my purposes but I thought it'd be helpful for you.