### PR TITLE
Fix handling of new block quote types

### DIFF
--- a/lib/AppleNoteStore.rb
+++ b/lib/AppleNoteStore.rb
@@ -890,6 +890,10 @@ class AppleNoteStore
     ul.dashed {
       list-style-type: '- ';
     }
+    blockquote.block-quote {
+      border-left: 3px solid #bdbdbd;
+      padding-left: 0.4rem;
+    }
     .checklist {
       position: relative;
       list-style: none;


### PR DESCRIPTION
New Notes versions support a special "block quote" type. The initial handling didn't quite work once nested styling elements came into play. This hopefully fixes things by changing how these "block quotes" elements are handled so they leverage more of the existing indent logic.

I think this should fix https://github.com/threeplanetssoftware/apple_cloud_notes_parser/issues/88, but let me know if you have any questions about this approach.

Here's an example of how a note looked in Apple Notes:

<img width="543" alt="Screenshot 2023-12-03 at 1 46 46 PM" src="https://github.com/threeplanetssoftware/apple_cloud_notes_parser/assets/12112/67a7ec2f-e271-4576-8b6c-12d3e30aff3c">

Here's the rendered HTML output from that:

<img width="956" alt="Screenshot 2023-12-03 at 1 47 21 PM" src="https://github.com/threeplanetssoftware/apple_cloud_notes_parser/assets/12112/84d3ea1f-47d6-49bd-9a2e-906d30c7447d">

And the raw HTML now:

```html
Quotes<br>
<blockquote class="block-quote" data-apple-notes-indent-amount="1">If politics is like show business, then the idea is not to pursue excellence, clarity or honesty but to <i>appear</i> as if you are, which is another matter altogether.<br><i>Neil Postman</i><br></blockquote>
<br>
<blockquote class="block-quote" data-apple-notes-indent-amount="1">
  Hello<br>World<br><br>Break<br><br>Another test<br>
  <blockquote data-apple-notes-indent-amount="2">Indent inside block quote<br>Line 2<br>
    <blockquote data-apple-notes-indent-amount="3">Increase Indent again inside block quote<br>Another line<br></blockquote>
  </blockquote>
</blockquote>
<br>
<br>
<blockquote class="block-quote" data-apple-notes-indent-amount="1">
  Indent<br>
  <blockquote data-apple-notes-indent-amount="2">Indent inside block quote<br>Blah<br>Foo bar<br></blockquote>
</blockquote>
```