### PR TITLE
Removes invalid filename characters from note titles

### DIFF
--- a/lib/AppleNoteStore.rb
+++ b/lib/AppleNoteStore.rb
@@ -1062,7 +1062,7 @@ class AppleNoteStore
     end
 
     @notes.each do |note_id, note|
-      note_file_name = note.title_as_filename('.html', use_uuid: use_uuid)
+      note_file_name = note.title_as_filename('.html', use_uuid: use_uuid).gsub(/[\/*"\<>?|:]/,"")
       note_path = if note.folder
                     backup_dir.join(note.folder.to_path, note_file_name)
                   else


### PR DESCRIPTION
If a note title contains any of the characters windows disallows when the flag --individual-files is thrown, it will crash. Amended this by calling gsub on the title_as_filename result and removing these characters.