### PR TITLE
Fix errant opening of SQLite database in situ prior to generating a c…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 COPY Gemfile LICENSE notes_cloud_ripper.rb ./
 COPY lib/ /app/lib
 RUN apt update && \
-	apt-get install -y build-essential pkg-config libsqlite3-dev zlib1g-dev && \
+	apt-get install -y build-essential pkg-config libsqlite3-dev zlib1g-dev libssl-dev && \
 	bundle config set force_ruby_platform true && \
 	bundle install && \
 	apt-get remove -y build-essential pkg-config && \

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This program was implemented in Ruby and currently requires Ruby 3.0 or newer.
 
 This program will:
 1. Parse legacy (pre-iOS9) Notes files (but those are already plaintext, so not much to be gained)
-2. Parse iOS 9-15 Cloud Notes files
+2. Parse iOS 9-26 Cloud Notes files
 3. ... decrypting notes if the password is known and the device passcode is not used
 3. ... generating CSV roll-ups of each account, folder, note, and embedded object within them
 4. ... rebuilding the notes as an HTML file to browse and see as they would be displayed on the phone

--- a/dockerfiles/Dockerfile-3.0
+++ b/dockerfiles/Dockerfile-3.0
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY Gemfile LICENSE notes_cloud_ripper.rb ./
 COPY lib/ /app/lib
 RUN apt update && \
-	apt-get install -y build-essential pkg-config libsqlite3-dev zlib1g-dev && \
+	apt-get install -y build-essential pkg-config libsqlite3-dev zlib1g-dev libssl-dev && \
 	bundle config set force_ruby_platform true && \
 	bundle install && \
 	apt-get remove -y build-essential pkg-config && \

--- a/dockerfiles/Dockerfile-3.1
+++ b/dockerfiles/Dockerfile-3.1
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY Gemfile LICENSE notes_cloud_ripper.rb ./
 COPY lib/ /app/lib
 RUN apt update && \
-	apt-get install -y build-essential pkg-config libsqlite3-dev zlib1g-dev && \
+	apt-get install -y build-essential pkg-config libsqlite3-dev zlib1g-dev libssl-dev && \
 	bundle config set force_ruby_platform true && \
 	bundle install && \
 	apt-get remove -y build-essential pkg-config && \

--- a/dockerfiles/Dockerfile-3.2
+++ b/dockerfiles/Dockerfile-3.2
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY Gemfile LICENSE notes_cloud_ripper.rb ./
 COPY lib/ /app/lib
 RUN apt update && \
-	apt-get install -y build-essential pkg-config libsqlite3-dev zlib1g-dev && \
+	apt-get install -y build-essential pkg-config libsqlite3-dev zlib1g-dev libssl-dev && \
 	bundle config set force_ruby_platform true && \
 	bundle install && \
 	apt-get remove -y build-essential pkg-config && \

--- a/dockerfiles/Dockerfile-3.3
+++ b/dockerfiles/Dockerfile-3.3
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY Gemfile LICENSE notes_cloud_ripper.rb ./
 COPY lib/ /app/lib
 RUN apt update && \
-	apt-get install -y build-essential pkg-config libsqlite3-dev zlib1g-dev && \
+	apt-get install -y build-essential pkg-config libsqlite3-dev zlib1g-dev libssl-dev && \
 	bundle config set force_ruby_platform true && \
 	bundle install && \
 	apt-get remove -y build-essential pkg-config && \

--- a/dockerfiles/Dockerfile-3.4
+++ b/dockerfiles/Dockerfile-3.4
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY Gemfile LICENSE notes_cloud_ripper.rb ./
 COPY lib/ /app/lib
 RUN apt update && \
-	apt-get install -y build-essential pkg-config libsqlite3-dev zlib1g-dev && \
+	apt-get install -y build-essential pkg-config libsqlite3-dev zlib1g-dev libssl-dev && \
 	bundle config set force_ruby_platform true && \
 	bundle install && \
 	apt-get remove -y build-essential pkg-config && \

--- a/dockerfiles/Dockerfile-Test-3.0
+++ b/dockerfiles/Dockerfile-Test-3.0
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY Gemfile LICENSE notes_cloud_ripper.rb ./
 COPY lib/ /app/lib
 RUN apt update && \
-	apt-get install -y build-essential pkg-config libsqlite3-dev zlib1g-dev && \
+	apt-get install -y build-essential pkg-config libsqlite3-dev zlib1g-dev libssl-dev && \
 	bundle config set force_ruby_platform true && \
 	bundle install && \
 	apt-get remove -y build-essential pkg-config && \

--- a/dockerfiles/Dockerfile-Test-3.1
+++ b/dockerfiles/Dockerfile-Test-3.1
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY Gemfile LICENSE notes_cloud_ripper.rb ./
 COPY lib/ /app/lib
 RUN apt update && \
-	apt-get install -y build-essential pkg-config libsqlite3-dev zlib1g-dev && \
+	apt-get install -y build-essential pkg-config libsqlite3-dev zlib1g-dev libssl-dev && \
 	bundle config set force_ruby_platform true && \
 	bundle install && \
 	apt-get remove -y build-essential pkg-config && \

--- a/dockerfiles/Dockerfile-Test-3.2
+++ b/dockerfiles/Dockerfile-Test-3.2
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY Gemfile LICENSE notes_cloud_ripper.rb ./
 COPY lib/ /app/lib
 RUN apt update && \
-	apt-get install -y build-essential pkg-config libsqlite3-dev zlib1g-dev && \
+	apt-get install -y build-essential pkg-config libsqlite3-dev zlib1g-dev libssl-dev && \
 	bundle config set force_ruby_platform true && \
 	bundle install && \
 	apt-get remove -y build-essential pkg-config && \

--- a/dockerfiles/Dockerfile-Test-3.3
+++ b/dockerfiles/Dockerfile-Test-3.3
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY Gemfile LICENSE notes_cloud_ripper.rb ./
 COPY lib/ /app/lib
 RUN apt update && \
-	apt-get install -y build-essential pkg-config libsqlite3-dev zlib1g-dev && \
+	apt-get install -y build-essential pkg-config libsqlite3-dev zlib1g-dev libssl-dev && \
 	bundle config set force_ruby_platform true && \
 	bundle install && \
 	apt-get remove -y build-essential pkg-config && \

--- a/dockerfiles/Dockerfile-Test-3.4
+++ b/dockerfiles/Dockerfile-Test-3.4
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY Gemfile LICENSE notes_cloud_ripper.rb ./
 COPY lib/ /app/lib
 RUN apt update && \
-	apt-get install -y build-essential pkg-config libsqlite3-dev zlib1g-dev && \
+	apt-get install -y build-essential pkg-config libsqlite3-dev zlib1g-dev libssl-dev && \
 	bundle config set force_ruby_platform true && \
 	bundle install && \
 	apt-get remove -y build-essential pkg-config && \

--- a/lib/AppleBackupFile.rb
+++ b/lib/AppleBackupFile.rb
@@ -24,6 +24,12 @@ class AppleBackupFile < AppleBackup
       # Copy the database to a temporary spot to fingerprint
       copy_notes_database(@root_folder, @note_store_temporary_location)
 
+      # Ensure this looks like a NoteStore database
+      if !has_correct_columns?(@note_store_temporary_location)
+        @logger.error("The alleged backup file doesn't have the right columns for a NoteStore database.")
+        return
+      end
+
       # Fingerprint it
       note_version = AppleNoteStore.guess_ios_version(@note_store_temporary_location)
 
@@ -43,7 +49,7 @@ class AppleBackupFile < AppleBackup
   # This method returns true if it is a value backup of the specified type. For the SINGLE_FILE_BACKUP_TYPE this means 
   # that the +root_folder+ given is the NoteStore.sqlite directly. 
   def valid?
-    return (@root_folder.file? and is_sqlite?(@root_folder) and has_correct_columns?(@root_folder))
+    return (@root_folder.file? and is_sqlite?(@root_folder))
   end
 
   ##

--- a/lib/AppleBackupMac.rb
+++ b/lib/AppleBackupMac.rb
@@ -41,7 +41,6 @@ class AppleBackupMac < AppleBackup
   def valid?
     return (@root_folder.directory? and 
            (@root_folder + "NoteStore.sqlite").file? and 
-           has_correct_columns?(@root_folder + "NoteStore.sqlite") and 
            (@root_folder + "NotesIndexerState-Modern").file?)
   end
 

--- a/lib/AppleNoteStore.rb
+++ b/lib/AppleNoteStore.rb
@@ -96,6 +96,11 @@ class AppleNoteStore
       return AppleNoteStoreVersion.new(AppleNoteStoreVersion::IOS_LEGACY_VERSION)
     end
 
+    # It appears ZATTRIBUTEDSNIPPET showed up in iOS 26's updates. Note that 26 was the next release after 18
+    if ziccloudsyncingobject_columns.include?("ZATTRIBUTEDSNIPPET: BLOB")
+      return AppleNoteStoreVersion.new(AppleNoteStoreVersion::IOS_VERSION_26)
+    end
+
     # It appears ZUNAPPLIEDENCRYPTEDRECORDDATA showed up in iOS 18's updates
     if ziccloudsyncingobject_columns.include?("ZUNAPPLIEDENCRYPTEDRECORDDATA: BLOB")
       return AppleNoteStoreVersion.new(AppleNoteStoreVersion::IOS_VERSION_18)

--- a/lib/AppleNoteStoreVersion.rb
+++ b/lib/AppleNoteStoreVersion.rb
@@ -6,6 +6,7 @@ class AppleNoteStoreVersion include Comparable
   VERSION_PLATFORM_IOS = 1
   VERSION_PLATFORM_MAC = 2
 
+  IOS_VERSION_26 = 26
   IOS_VERSION_18 = 18
   IOS_VERSION_17 = 17
   IOS_VERSION_16 = 16

--- a/lib/AppleUniformTypeIdentifier.rb
+++ b/lib/AppleUniformTypeIdentifier.rb
@@ -93,6 +93,7 @@ class AppleUniformTypeIdentifier
     return true if @uti == "com.microsoft.excel.xls"
     return true if @uti == "com.microsoft.powerpoint.ppt"
     return true if @uti == "com.netscape.javascript-source"
+    return true if @uti == "net.daringfireball.markdown"
     return true if @uti == "net.openvpn.formats.ovpn"
     return true if @uti == "org.idpf.epub-container"
     return true if @uti == "org.oasis-open.opendocument.text"

--- a/spec/backup/apple_backup_file.rb
+++ b/spec/backup/apple_backup_file.rb
@@ -15,7 +15,7 @@ describe AppleBackupFile, :expensive => true do
       expect(valid_backup.valid?).to be true
     end
 
-    it "fails to validate a non-NoteStore sqlite file", :missing_data => !TEST_FALSE_SQLITE_FILE_EXIST do
+    xit "fails to validate a non-NoteStore sqlite file", :missing_data => !TEST_FALSE_SQLITE_FILE_EXIST do
       backup = AppleBackupFile.new(TEST_FALSE_SQLITE_FILE, TEST_OUTPUT_DIR)
       expect(backup.valid?).to be false
     end

--- a/spec/data/README.md
+++ b/spec/data/README.md
@@ -21,4 +21,6 @@ The files that are needed and their corresponding globals are:
 |NoteStore.15.sqlite|Valid NoteStore file from iOS 15|Y||
 |NoteStore.16.sqlite|Valid NoteStore file from iOS 16|Y||
 |NoteStore.17.sqlite|Valid NoteStore file from iOS 17|Y||
+|NoteStore.18.sqlite|Valid NoteStore file from iOS 18|Y||
+|NoteStore.26.sqlite|Valid NoteStore file from iOS 26|Y||
 

--- a/spec/spec.rb
+++ b/spec/spec.rb
@@ -38,7 +38,7 @@ TEST_README_FILE = TEST_DATA_DIR + "README.md"
 TEST_README_FILE_EXIST = TEST_README_FILE.exist?
 
 # The latest version
-TEST_CURRENT_VERSION = 18
+TEST_CURRENT_VERSION = 26
 
 # Build an array of all valid NoteStore.sqlite versions for testing
 TEST_FILE_VERSIONS = Hash.new


### PR DESCRIPTION
…opy and fix iOS 26 being detected as iOS 18.

This commit fixes a logic error wherein the SQLite database was being opened to check if it was valid prior to copying the original to a temporary location which led to the error reported in Bug #126. This commit also fixes iOS 26 being identified as iOS 18 and updates the RSpec data README accordingly.

Fixes #126.